### PR TITLE
Naive fix for pytest>6

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2
@@ -29,5 +29,5 @@ jobs:
         python setup.py develop
     - name: Test with pytest
       run: |
-        pip install "pytest<6.0.0" pytest-pycodestyle pytest-flakes
+        pip install pytest-pycodestyle pytest-flakes
         py.test -v --pycodestyle --flakes pytest_quickcheck tests

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,5 +29,5 @@ jobs:
         python setup.py develop
     - name: Test with pytest
       run: |
-        pip install pytest-pycodestyle pytest-flakes
+        pip install pytest pytest-pycodestyle pytest-flakes
         py.test -v --pycodestyle --flakes pytest_quickcheck tests

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
-VERSION = "0.8.6"
-REQUIRES = ["pytest>=4.0,<6.0.0"]
+VERSION = "0.9.0"
+REQUIRES = ["pytest>=4.0"]
 
 try:
     LONG_DESCRIPTION = "".join([
@@ -20,9 +20,10 @@ CLASSIFIERS = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Utilities",
     "Topic :: Software Development :: Testing",
     "Topic :: Software Development :: Libraries",

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27, py36, py37, py38, py39, pypy3
+envlist = py27, py37, py38, py39, py310, pypy3
 
 [testenv:py27]
 commands = py.test -v --flakes --ignore=tests/python3 pytest_quickcheck tests
 
 [testenv]
 deps =
-    pytest<6.0.0
+    pytest>=4.0
     pytest-pycodestyle
     pytest-flakes
 


### PR DESCRIPTION
Hi, I checked, everything works for my needs, only
```
PytestDeprecationWarning: A private pytest class or function was used.
    _randomize = Mark("randomize", args, {})
```
But up to version 8 of pytest it's not a big deal.